### PR TITLE
fix(app): mkdir when package has sub-directories

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 		log.Fatal(errors.Wrap(err, "unable to instantiate formatter"))
 	}
 
-	if err := os.Mkdir(args.Output, 0755); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(args.Output, 0755); err != nil && !os.IsExist(err) {
 		log.Fatal(errors.Wrap(err, "unable to create output directory"))
 	}
 
@@ -93,7 +93,7 @@ func main() {
 
 		log.Printf("building index for package '%s' in '%s'", pkg.Name, target)
 
-		if err := os.Mkdir(path.Dir(target), 0755); err != nil && !os.IsExist(err) {
+		if err := os.MkdirAll(path.Dir(target), 0755); err != nil && !os.IsExist(err) {
 			log.Fatal(errors.Wrap(err, "unable to create package output directory"))
 		}
 
@@ -116,7 +116,7 @@ func main() {
 			subTarget := path.Join(args.Output, pkg.Name, subName, indexFile)
 			log.Printf("building index for subpackage '%s' of '%s' in '%s'", subName, pkg.Name, subTarget)
 
-			if err := os.Mkdir(path.Dir(subTarget), 0755); err != nil && !os.IsExist(err) {
+			if err := os.MkdirAll(path.Dir(subTarget), 0755); err != nil && !os.IsExist(err) {
 				log.Fatal(errors.Wrap(err, "unable to create package output directory"))
 			}
 


### PR DESCRIPTION
When package name contained '/' vanitygen failed to create a directories.

    pkgs:
      # v2 and v1 are not public for some reson
      - name: foo/v3
        provider: github
        repoUrl: "https://github.com/foo/foo"
        branch: master

resulted in

    2024/08/20 22:10:31 building index for package 'foo/v3' in 'out/foo/v3/index.html'
    2024/08/20 22:10:31 unable to create package output directory: mkdir out/foo/v3: no such file or directory
    exit status 1